### PR TITLE
Reverse saved posts order to prevent big Github repos

### DIFF
--- a/app/data/PostList.php
+++ b/app/data/PostList.php
@@ -61,6 +61,11 @@ class PostList
     /**
      * Fetches a page of posts from the API. Optionally save the data to disk.
      *
+     * Note that we query and save with the oldest posts first. This is so that
+     * when we do content updates, we minimise the change in the Git repository.
+     * This does mean that the JS also needs to reverse the order of the posts
+     * when displaying them to get them back in reverse-chronological order.
+     *
      * @param int $page
      * @param bool|null $saveToDisk
      * @return Collection<Post>
@@ -69,7 +74,7 @@ class PostList
     {
         echo "Fetching page $page of {$this->pages} for {$this->postType}\n";
         $type = $this->postType;
-        $response = WordPressResponse::fromArray(wordpress()->$type()->withOptions(['verify' => false])
+        $response = WordPressResponse::fromArray(wordpress()->$type()->oldest()->withOptions(['verify' => false])
             ->page($page)
             ->get());
         $response->page = $page;

--- a/resources/js/main.js
+++ b/resources/js/main.js
@@ -69,6 +69,7 @@ document.addEventListener('alpine:init', () => {
                 await this.loadMeta('pages');
                 // await this.loadPage('/data/index.html', false);
                 // await this.loadPage('/data/home/', true);
+                this.currentPageNumber = this.siteMeta.posts.pages;
                 await this.loadPage('/', false);
                 this.setWatchHandlersOnLinks();
             },
@@ -106,14 +107,16 @@ document.addEventListener('alpine:init', () => {
                 if (path === '/') {
                     // Fetch the posts list
                     try {
-                        const response = await fetch(`/data/posts/1.json`);
+                        const lastPageNumber = this.siteMeta.posts.pages;
+                        const response = await fetch(`/data/posts/${lastPageNumber}.json`);
                         const data = await response.json();
                         this.currentUrl = '/';
                         this.currentData = null;
                         this.currentHtml = null;
                         this.currentPosts = null;
                         console.log(data);
-                        this.currentPosts = data;
+                        // Posts are ordered oldest first, so reverse before adding
+                        this.currentPosts = data.reverse();
                     } catch (error) {
                         console.error(error);
                     }
@@ -186,18 +189,19 @@ document.addEventListener('alpine:init', () => {
              * Loads the next page of posts.
              */
             async loadMorePosts() {
-                if (this.currentPageNumber >= this.siteMeta.posts.totalPages) {
+                if (this.currentPageNumber < 1) {
                     return;
                 }
 
-                this.currentPageNumber++;
+                this.currentPageNumber--;
 
                 try {
                     const response = await fetch(`/data/posts/${this.currentPageNumber}.json`);
                     const data = await response.json();
-                    // Add the new data to the existing posts
-                    this.currentPosts = this.currentPosts.concat(data);
-                } catch (error) {
+                    // Add the new data to the existing posts. Note that items are
+                    // ordered oldest first, so we need to reverse the new data before
+                    // adding it.
+                    this.currentPosts = this.currentPosts.concat(data.reverse());                } catch (error) {
                     console.error(error);
                 }
 


### PR DESCRIPTION
Resolves #2 

Saves post lists in ascending date order. This reduces (greatly!) the changes in Git when content is added.

The front-end is tweaked to read them in the right order too!